### PR TITLE
[WIP] Add `report_file` parameter to Android_lint plugin

### DIFF
--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -25,7 +25,18 @@ module Danger
   class DangerAndroidLint < Plugin
 
     SEVERITY_LEVELS = ["Warning", "Error", "Fatal"]
-    REPORT_FILE = "app/build/reports/lint/lint-result.xml"
+
+    # Location of lint report file
+    # If your Android lint task outputs to a different location, you can specify it here.
+    # Defaults to "app/build/reports/lint/lint-result.xml".
+    # @return [String]
+    attr_accessor :report_file
+    # A getter for `severity`, returning "Warning" if value is nil.
+    # @return [String]
+    def report_file
+      @report_file || 'app/build/reports/lint/lint-result.xml'
+    end
+    REPORT_FILE = @report_file
 
     # Custom gradle task to run.
     # This is useful when your project has different flavors.

--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -31,12 +31,11 @@ module Danger
     # Defaults to "app/build/reports/lint/lint-result.xml".
     # @return [String]
     attr_accessor :report_file
-    # A getter for `severity`, returning "Warning" if value is nil.
+    # A getter for `report_file`.
     # @return [String]
     def report_file
-      @report_file || 'app/build/reports/lint/lint-result.xml'
+      return @report_file || 'app/build/reports/lint/lint-result.xml'
     end
-    REPORT_FILE = @report_file
 
     # Custom gradle task to run.
     # This is useful when your project has different flavors.
@@ -70,8 +69,8 @@ module Danger
 
       system "./gradlew #{gradle_task || 'lint'}"
 
-      unless File.exists?(REPORT_FILE)
-        fail("Lint report not found at `#{REPORT_FILE}`. "\
+      unless File.exists?(report_file)
+        fail("Lint report not found at `#{report_file}`. "\
           "Have you forgot to add `xmlReport true` to your `build.gradle` file?")
       end
 
@@ -91,7 +90,7 @@ module Danger
     private
 
     def read_issues_from_report
-      file = File.open("app/build/reports/lint/lint-result.xml")
+      file = File.open(report_file)
 
       require 'oga'
       report = Oga.parse_xml(file)

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -21,6 +21,7 @@ module Danger
 
       it "Fails if severity is an unknown value" do
         allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
+        allow(File).to receive(:exists?).with(@android_lint.report_file()).and_return(true)
 
         @android_lint.severity = "Dummy"
         @android_lint.lint
@@ -30,10 +31,10 @@ module Danger
 
       it "Sets severity to 'Warning' if no severity param is provided" do
         allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
-        allow(File).to receive(:exists?).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(true)
+        allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(true)
 
         fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
-        allow(File).to receive(:open).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(fake_result)
+        allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
 
         @android_lint.lint
         expect(@android_lint.severity).to eq("Warning")
@@ -41,10 +42,10 @@ module Danger
 
       it "Fails if report file does not exist" do
         allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
-        allow(File).to receive(:exists?).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(false)
+        allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(false)
 
         fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
-        allow(File).to receive(:open).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(fake_result)
+        allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
 
         @android_lint.lint
 
@@ -55,12 +56,12 @@ module Danger
       describe 'lint' do
         before do
           allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
-          allow(File).to receive(:exists?).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(false)
+          allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(false)
         end
 
         it 'Prints markdown if issues were found' do
           fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
-          allow(File).to receive(:open).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(fake_result)
+          allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
 
           @android_lint.lint
 
@@ -79,7 +80,7 @@ module Danger
 
         it 'Doesn`t print anything if no errors were found' do
           fake_result = File.open("spec/fixtures/lint-result-empty.xml")
-          allow(File).to receive(:open).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(fake_result)
+          allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
 
           @android_lint.lint
 
@@ -89,7 +90,7 @@ module Danger
 
         it 'Doesn`t print anything if no errors were found' do
           fake_result = File.open("spec/fixtures/lint-result-without-fatal.xml")
-          allow(File).to receive(:open).with(Danger::DangerAndroidLint::REPORT_FILE).and_return(fake_result)
+          allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
 
           @android_lint.severity = "Fatal"
           @android_lint.lint

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -40,6 +40,30 @@ module Danger
         expect(@android_lint.severity).to eq("Warning")
       end
 
+      it "Sets the report file to a default location if no param is provided" do
+        allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
+        allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(true)
+        
+        fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
+        allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
+
+        @android_lint.lint
+        expect(@android_lint.report_file).to eq("app/build/reports/lint/lint-result.xml")
+      end
+
+      it "Sets the report_file to the user's preference in the Dangerfile'" do
+        allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
+        allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(false)
+        
+        fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
+        allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
+
+        @android_lint.report_file = 'some/other/location/lint-result.xml'
+        @android_lint.lint
+
+        expect(@android_lint.report_file).to eq('some/other/location/lint-result.xml')
+      end
+
       it "Fails if report file does not exist" do
         allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
         allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(false)

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -53,12 +53,13 @@ module Danger
 
       it "Sets the report_file to the user's preference in the Dangerfile'" do
         allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
-        allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(false)
-        
-        fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
-        allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
 
         @android_lint.report_file = 'some/other/location/lint-result.xml'
+
+        fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
+        allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
+        allow(File).to receive(:exists?).with(@android_lint.report_file).and_return(true)
+        
         @android_lint.lint
 
         expect(@android_lint.report_file).to eq('some/other/location/lint-result.xml')


### PR DESCRIPTION
This adds a new option to the android lint plugin, allowing the user to
set their report file location in the Dangerfile, using something like:

`android_lint.report_file = "/app/build/output/lint/lint.xml"`

The default report file location is at:
'app/build/reports/lint/lint-result.xml'