### PR TITLE
Support inline mode

### DIFF
--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -56,7 +56,7 @@ module Danger
     # It fails if `xmlReport` configuration is not set to `true` in your `build.gradle` file.
     # @return [void]
     #
-    def lint
+    def lint(inline_mode: false)
       unless gradlew_exists?
         fail("Could not find `gradlew` inside current directory")
         return
@@ -77,8 +77,13 @@ module Danger
       issues = read_issues_from_report
       filtered_issues = filter_issues_by_severity(issues)
 
-      message = message_for_issues(filtered_issues)
-      markdown(message) unless filtered_issues.empty?
+      if inline_mode
+        # Report with inline comment
+        send_inline_comment(filtered_issues)
+      else
+        message = message_for_issues(filtered_issues)
+        markdown(message) unless filtered_issues.empty?
+      end
     end
 
     # A getter for `severity`, returning "Warning" if value is nil.
@@ -120,6 +125,8 @@ module Danger
     end
 
     def parse_results(results, heading)
+      target_files = (git.modified_files - git.deleted_files) + git.added_files
+      dir = "#{Dir.pwd}/"
       message = "#### #{heading} (#{results.count})\n\n"
 
       message << "| File | Line | Reason |\n"
@@ -127,7 +134,8 @@ module Danger
 
       results.each do |r|
         location = r.xpath('location').first
-        filename = location.get('file').split('/').last
+        filename = location.get('file').gsub(dir, "")
+        next unless target_files.include? filename
         line = location.get('line') || 'N/A'
         reason = r.get('message')
 
@@ -135,6 +143,26 @@ module Danger
       end
 
       message
+    end
+
+
+    # Send inline comment with danger's warn or fail method
+    #
+    # @return [void]
+    def send_inline_comment (issues)
+      target_files = (git.modified_files - git.deleted_files) + git.added_files
+      dir = "#{Dir.pwd}/"
+      SEVERITY_LEVELS.reverse.each do |level|
+        filtered = issues.select{|issue| issue.get("severity") == level}
+        next if filtered.empty?
+        filtered.each do |r|
+          location = r.xpath('location').first
+          filename = location.get('file').gsub(dir, "")
+          next unless target_files.include? filename
+          line = (location.get('line') || "0").to_i
+          send(level === "Warning" ? "warn" : "fail", r.get('message'), file: filename, line: line)
+        end
+      end
     end
 
     def gradlew_exists?

--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -50,6 +50,10 @@ module Danger
     # @return [String]
     attr_writer :severity
 
+    # Enable filtering
+    # Only show messages within changed files.
+    attr_accessor :filtering
+
     # Calls lint task of your gradle project.
     # It fails if `gradlew` cannot be found inside current directory.
     # It fails if `severity` level is not a valid option.
@@ -135,7 +139,7 @@ module Danger
       results.each do |r|
         location = r.xpath('location').first
         filename = location.get('file').gsub(dir, "")
-        next unless target_files.include? filename
+        next unless !filtering || (target_files.include? filename)
         line = location.get('line') || 'N/A'
         reason = r.get('message')
 
@@ -158,7 +162,7 @@ module Danger
         filtered.each do |r|
           location = r.xpath('location').first
           filename = location.get('file').gsub(dir, "")
-          next unless target_files.include? filename
+          next unless !filtering || (target_files.include? filename)
           line = (location.get('line') || "0").to_i
           send(level === "Warning" ? "warn" : "fail", r.get('message'), file: filename, line: line)
         end

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -10,6 +10,12 @@ module Danger
       before do
         @dangerfile = testing_dangerfile
         @android_lint = @dangerfile.android_lint
+        allow(@android_lint.git).to receive(:deleted_files).and_return([])
+        allow(@android_lint.git).to receive(:added_files).and_return([])
+        allow(@android_lint.git).to receive(:modified_files).and_return([
+          "/Users/gustavo/Developer/app-android/app/src/main/java/com/loadsmart/common/views/AvatarView.java",
+          "/Users/gustavo/Developer/app-android/app/src/main/java/com/loadsmart/analytics/Events.java"
+        ])
       end
 
       it "Fails if gradlew does not exist" do
@@ -94,13 +100,13 @@ module Danger
           expect(markdown).to include("AndroidLint found issues")
 
           expect(markdown).to include("Fatal (1)")
-          expect(markdown).to include("`AvatarView.java` | 60 | Implicitly using the default locale is a common source of bugs: Use `toUpperCase(Locale)` instead")
+          expect(markdown).to include("`/Users/gustavo/Developer/app-android/app/src/main/java/com/loadsmart/common/views/AvatarView.java` | 60 | Implicitly using the default locale is a common source of bugs: Use `toUpperCase(Locale)` instead")
 
           expect(markdown).to include("Error (1)")
-          expect(markdown).to include("`Events.java` | 21 | Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
+          expect(markdown).to include("`/Users/gustavo/Developer/app-android/app/src/main/java/com/loadsmart/analytics/Events.java` | 21 | Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
 
           expect(markdown).to include("Warning (1)")
-          expect(markdown).to include("`Events.java` | 24 | Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
+          expect(markdown).to include("`/Users/gustavo/Developer/app-android/app/src/main/java/com/loadsmart/analytics/Events.java` | 24 | Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
         end
 
         it 'Doesn`t print anything if no errors were found' do
@@ -122,6 +128,19 @@ module Danger
 
           markdown = @android_lint.status_report[:markdowns].first
           expect(markdown).to be_nil
+        end
+
+        it 'Send inline comment instead of markdown' do
+          fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
+          allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
+
+          @android_lint.lint inline_mode: true
+          error = @android_lint.status_report[:errors]
+          expect(error).to include("Implicitly using the default locale is a common source of bugs: Use `toUpperCase(Locale)` instead")
+          expect(error).to include("Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
+
+          warn = @android_lint.status_report[:warnings]
+          expect(warn).to include("Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
         end
 
       end

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -143,6 +143,24 @@ module Danger
           expect(warn).to include("Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
         end
 
+        it 'Only show comment in changed files' do
+          allow(@android_lint.git).to receive(:modified_files).and_return([
+          "/Users/gustavo/Developer/app-android/app/src/main/java/com/loadsmart/common/views/AvatarView.java",
+          ])
+
+          fake_result = File.open("spec/fixtures/lint-result-with-everything.xml")
+          allow(File).to receive(:open).with(@android_lint.report_file).and_return(fake_result)
+
+          @android_lint.filtering = true
+          @android_lint.lint inline_mode: true
+          error = @android_lint.status_report[:errors]
+          expect(error).to include("Implicitly using the default locale is a common source of bugs: Use `toUpperCase(Locale)` instead")
+          expect(error).not_to include("Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
+
+          warn = @android_lint.status_report[:warnings]
+          expect(warn).not_to include("Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead")
+        end
+
       end
 
     end


### PR DESCRIPTION
Since danger support inline comment for github, add an option to support send lint result as a inline comment.
Also dismiss all result that not belong to running PR(i think show all lint result in PR seems to be a bit verbose)