### PR TITLE
Support multiple gradle modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ android_lint.gradle_task = "lintMyFlavorDebug"
 android_lint.lint
 ```
 
+In case you have multiple modules, you may want to change the gradle modules. You can achieve that by changing the value of `gradle_modules`. Default is `nil`.
+
+```rb
+android_lint.gradle_modules = ["app", "library"]
+```
+
+In case your Android gradle project is not equals to root directory of repository. You can achieve that by changing the value of `gradle_project`. Default is repository's root directory.
+
+```rb
+android_lint.gradle_project = "YourAndroidProjectDir/"
+```
+
 If you want to skip gradle task, setting the `skip_gradle_task` parameter to `true`.
 
 ```rb

--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -43,8 +43,7 @@ module Danger
     # @return [String]
     attr_accessor :gradle_task
 
-    # Custom gradle module to run.
-    # This is useful when your project has different flavors.
+    # Custom multiple gradle module to run.
     # Defaults to [nil].
     # @return [Array]
     attr_writer :gradle_modules


### PR DESCRIPTION
Hi,

I want to use this plugin at project what has multiple gradle modules.

And it be used [like this](https://github.com/WataruSuzuki/Android-Example-Using-Danger/pull/4). 
Of course also we can use [simply](https://github.com/WataruSuzuki/Android-Example-Using-Danger/pull/3) as former use case.

Best regards