### PR TITLE
Add option to skip Gradle task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ android_lint.gradle_task = "lintMyFlavorDebug"
 android_lint.lint
 ```
 
+#### Skip gradle task execution
+
+If you want to skip the gradle task execution. You can achieve that by simply changing the value of `skip_gradle_task`. Default is `false`.
+
+```rb
+android_lint.skip_gradle_task = true
+android_lint.lint
+```
+
 #### Changing report's severity level
 
 If you want to filter lint issues based on their severity level, you can do that by setting a value to `severity`. Bear in mind that you are filtering issues by the severity level you've set **and up**. Possible values are `Warning`, `Error` and `Fatal`. Default is `Warning` (which is everything).

--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -36,6 +36,7 @@ module Danger
     # Defaults to "app/build/reports/lint/lint-result.xml".
     # @return [String]
     attr_accessor :report_file
+
     # A getter for `report_file`.
     # @return [String]
     def report_file
@@ -54,12 +55,24 @@ module Danger
     # @return [Bool]
     attr_writer :skip_gradle_task
 
+    # A getter for `skip_gradle_task`, returning `false` if value is nil.
+    # @return [Boolean]
+    def skip_gradle_task
+      @skip_gradle_task ||= false
+    end
+
     # Defines the severity level of the execution.
     # Selected levels are the chosen one and up.
     # Possible values are "Warning", "Error" or "Fatal".
     # Defaults to "Warning".
     # @return [String]
     attr_writer :severity
+
+    # A getter for `severity`, returning "Warning" if value is nil.
+    # @return [String]
+    def severity
+      @severity || SEVERITY_LEVELS.first
+    end
 
     # Enable filtering
     # Only show messages within changed files.
@@ -100,18 +113,6 @@ module Danger
         message = message_for_issues(filtered_issues)
         markdown(message) unless filtered_issues.empty?
       end
-    end
-
-    # A getter for `skip_gradle_task`, returning `false` if value is nil.
-    # @return [Boolean]
-    def skip_gradle_task
-      @skip_gradle_task ||= false
-    end
-
-    # A getter for `severity`, returning "Warning" if value is nil.
-    # @return [String]
-    def severity
-      @severity || SEVERITY_LEVELS.first
     end
 
     private

--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -49,6 +49,12 @@ module Danger
     # @return [String]
     attr_accessor :gradle_task
 
+    # A getter for `gradle_task`, returning "lint" if value is nil.
+    # @return [String]
+    def gradle_task
+      @gradle_task ||= "lint"
+    end
+
     # Skip Gradle task.
     # This is useful when Gradle task has been already executed.
     # Defaults to `false`.
@@ -95,7 +101,7 @@ module Danger
       end
 
       unless skip_gradle_task
-        system "./gradlew #{gradle_task || 'lint'}"
+        system "./gradlew #{gradle_task}"
       end
 
       unless File.exists?(report_file)

--- a/lib/android_lint/plugin.rb
+++ b/lib/android_lint/plugin.rb
@@ -48,8 +48,8 @@ module Danger
     # @return [String]
     attr_accessor :gradle_task
 
-    # Skip Gradle task
-    # If you skip Gradle task, for example project does not manage Gradle.
+    # Skip Gradle task.
+    # This is useful when Gradle task has been already executed.
     # Defaults to `false`.
     # @return [Bool]
     attr_writer :skip_gradle_task

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -25,6 +25,16 @@ module Danger
         expect(@android_lint.status_report[:errors]).to eq(["Could not find `gradlew` inside current directory"])
       end
 
+      it "Skip Gradle task" do
+        skip_gradle_task = true
+        @android_lint.skip_gradle_task = skip_gradle_task
+        expect(@android_lint.skip_gradle_task).to eq(skip_gradle_task)
+      end
+
+      it "Check default skip Gradle task" do
+        expect(@android_lint.skip_gradle_task).to eq(false)
+      end
+
       it "Fails if severity is an unknown value" do
         allow(@android_lint).to receive(:`).with("ls gradlew").and_return("gradlew")
         allow(File).to receive(:exists?).with(@android_lint.report_file()).and_return(true)

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -25,14 +25,14 @@ module Danger
         expect(@android_lint.status_report[:errors]).to eq(["Could not find `gradlew` inside current directory"])
       end
 
-      it "Check default Gradle task" do
-        expect(@android_lint.gradle_task).to eq("lint")
-      end
-
       it "Set custom Gradle task" do
         custom_task = "lintRelease"
         @android_lint.gradle_task = custom_task
         expect(@android_lint.gradle_task).to eq(custom_task)
+      end
+
+      it "Check default Gradle task" do
+        expect(@android_lint.gradle_task).to eq("lint")
       end
 
       it "Skip Gradle task" do

--- a/spec/android_lint_spec.rb
+++ b/spec/android_lint_spec.rb
@@ -25,6 +25,16 @@ module Danger
         expect(@android_lint.status_report[:errors]).to eq(["Could not find `gradlew` inside current directory"])
       end
 
+      it "Check default Gradle task" do
+        expect(@android_lint.gradle_task).to eq("lint")
+      end
+
+      it "Set custom Gradle task" do
+        custom_task = "lintRelease"
+        @android_lint.gradle_task = custom_task
+        expect(@android_lint.gradle_task).to eq(custom_task)
+      end
+
       it "Skip Gradle task" do
         skip_gradle_task = true
         @android_lint.skip_gradle_task = skip_gradle_task


### PR DESCRIPTION
In some case the Gradle task execution can be skipped. This PR add a new option to do it.